### PR TITLE
fix velocity

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleImpactComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleImpactComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Shuttles.Components
         /// Минимальная разница скоростей между двумя телами, при которой происходит "удар" шаттла.
         /// </summary>
         [DataField("minimumImpactVelocity")]
-        public int MinimumImpactVelocity = 15;
+        public int MinimumImpactVelocity = 21;
 
         /// <summary>
         /// Кинетическая энергия, необходимая для разрушения одной плитки.


### PR DESCRIPTION


## About the PR
Ну, в связи повышение скорости шаттла - нужно было подкорректировать минимальную скорость при столкновение шаттлов.

## Why / Balance
- Изменено минимальная скорость для разрушение при столкновение двух гридов:
 Было минимум 15
 Стало - 21


## How to test
Протестирован и работает стабильно
